### PR TITLE
fix: tests.pyの未使用importを削除

### DIFF
--- a/spots/tests.py
+++ b/spots/tests.py
@@ -1,8 +1,8 @@
-from django.test import TestCase, Client
+from django.test import TestCase
 from django.contrib.auth.models import User
 from django.urls import reverse
 
-from .models import Category, Spot, Like, Bookmark, Comment
+from .models import Category, Spot, Like, Bookmark
 
 
 class CategoryModelTest(TestCase):


### PR DESCRIPTION
## 概要
- `Client` (django.test) の未使用importを削除
- `Comment` (.models) の未使用importを削除

CIのflake8 F401エラーを解消。