### PR TITLE
flake8 lintエラー修正: 未使用変数の削除

### DIFF
--- a/spots/tests.py
+++ b/spots/tests.py
@@ -317,7 +317,7 @@ class SpotCommentPostTest(TestCase):
     def test_post_comment_creates_comment(self):
         """ログイン済みユーザーがスポット詳細にPOSTするとコメントが作成される"""
         url = reverse("spots:spot_detail", kwargs={"pk": self.spot.pk})
-        response = self.client.post(url, {"text": "素晴らしいスポットです！"})
+        self.client.post(url, {"text": "素晴らしいスポットです！"})
         self.assertEqual(Comment.objects.filter(spot=self.spot).count(), 1)
         self.assertEqual(Comment.objects.first().text, "素晴らしいスポットです！")
 


### PR DESCRIPTION
## 概要

- `spots/tests.py` の `test_post_comment_creates_comment` メソッドで、使用されていないローカル変数 `response` を削除
- flake8 F841 (local variable is assigned to but never used) の解消

## 変更内容

`response = self.client.post(...)` を `self.client.post(...)` に変更。
このテストメソッドはコメント作成の検証が目的であり、レスポンスの検証は別テスト（`test_post_comment_redirects_to_detail`）で行っているため、`response` 変数は不要。