### PR TITLE
Djangoバージョン制約修正とページネーションの追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django>=4.2,<5.0
+Django>=5.2,<6.0
 Pillow>=10.0

--- a/spots/tests.py
+++ b/spots/tests.py
@@ -80,6 +80,20 @@ class HomeViewTest(TestCase):
         response = self.client.get(reverse("spots:home"))
         self.assertEqual(response.status_code, 200)
 
+    def test_home_pagination(self):
+        """ホームページがページネーションで12件ずつ表示される"""
+        user = User.objects.create_user(username="taro", password="pass1234")
+        cat = Category.objects.create(name="カフェ", slug="cafe")
+        for i in range(15):
+            Spot.objects.create(
+                author=user, title=f"スポット{i}", description="説明",
+                area="渋谷", category=cat,
+            )
+        response = self.client.get(reverse("spots:home"))
+        self.assertEqual(len(response.context["spots"]), 12)
+        response2 = self.client.get(reverse("spots:home") + "?page=2")
+        self.assertEqual(len(response2.context["spots"]), 3)
+
 
 class SpotDetailViewTest(TestCase):
     def setUp(self):

--- a/spots/views.py
+++ b/spots/views.py
@@ -1,13 +1,19 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
+from django.core.paginator import Paginator
 from django.http import JsonResponse
 from django.db.models import Q
 from .models import Spot, SpotImage, Like, Bookmark, Category
 from .forms import SpotForm, CommentForm
 
+SPOTS_PER_PAGE = 12
+
 
 def home(request):
-    spots = Spot.objects.select_related("author", "category").prefetch_related("images")[:20]
+    spot_list = Spot.objects.select_related("author", "category").prefetch_related("images")
+    paginator = Paginator(spot_list, SPOTS_PER_PAGE)
+    page_number = request.GET.get("page")
+    spots = paginator.get_page(page_number)
     categories = Category.objects.all()
     return render(request, "spots/home.html", {"spots": spots, "categories": categories})
 
@@ -128,9 +134,12 @@ def spot_search(request):
     if area:
         spots = spots.filter(area__icontains=area)
 
+    paginator = Paginator(spots, SPOTS_PER_PAGE)
+    page_number = request.GET.get("page")
+    page_obj = paginator.get_page(page_number)
     categories = Category.objects.all()
     return render(
         request,
         "spots/search.html",
-        {"spots": spots[:40], "categories": categories, "q": q, "category_slug": category_slug, "area": area},
+        {"spots": page_obj, "categories": categories, "q": q, "category_slug": category_slug, "area": area},
     )

--- a/templates/spots/home.html
+++ b/templates/spots/home.html
@@ -43,6 +43,24 @@
   </div>
   {% endfor %}
 </div>
+{% if spots.has_other_pages %}
+<nav class="mt-4" aria-label="ページナビゲーション">
+  <ul class="pagination justify-content-center">
+    {% if spots.has_previous %}
+    <li class="page-item"><a class="page-link" href="?page={{ spots.previous_page_number }}">前へ</a></li>
+    {% endif %}
+    {% for num in spots.paginator.page_range %}
+    <li class="page-item {% if spots.number == num %}active{% endif %}">
+      <a class="page-link" href="?page={{ num }}">{{ num }}</a>
+    </li>
+    {% endfor %}
+    {% if spots.has_next %}
+    <li class="page-item"><a class="page-link" href="?page={{ spots.next_page_number }}">次へ</a></li>
+    {% endif %}
+  </ul>
+</nav>
+{% endif %}
+
 {% else %}
 <div class="text-center py-5">
   <i class="bi bi-geo-alt" style="font-size:3rem;color:#ccc;"></i>

--- a/templates/spots/search.html
+++ b/templates/spots/search.html
@@ -33,7 +33,7 @@
 </div>
 
 {% if spots %}
-<p class="text-muted small mb-3">{{ spots|length }}件のスポットが見つかりました</p>
+<p class="text-muted small mb-3">{{ spots.paginator.count }}件のスポットが見つかりました</p>
 <div class="row g-3">
   {% for spot in spots %}
   <div class="col-6 col-md-4 col-lg-3">
@@ -56,6 +56,25 @@
   </div>
   {% endfor %}
 </div>
+
+{% if spots.has_other_pages %}
+<nav class="mt-4" aria-label="ページナビゲーション">
+  <ul class="pagination justify-content-center">
+    {% if spots.has_previous %}
+    <li class="page-item"><a class="page-link" href="?q={{ q }}&category={{ category_slug }}&area={{ area }}&page={{ spots.previous_page_number }}">前へ</a></li>
+    {% endif %}
+    {% for num in spots.paginator.page_range %}
+    <li class="page-item {% if spots.number == num %}active{% endif %}">
+      <a class="page-link" href="?q={{ q }}&category={{ category_slug }}&area={{ area }}&page={{ num }}">{{ num }}</a>
+    </li>
+    {% endfor %}
+    {% if spots.has_next %}
+    <li class="page-item"><a class="page-link" href="?q={{ q }}&category={{ category_slug }}&area={{ area }}&page={{ spots.next_page_number }}">次へ</a></li>
+    {% endif %}
+  </ul>
+</nav>
+{% endif %}
+
 {% else %}
 <div class="text-center py-5">
   <i class="bi bi-search" style="font-size:3rem;color:#ccc;"></i>


### PR DESCRIPTION
## 変更概要
- `requirements.txt`: Djangoバージョン制約を`>=5.2,<6.0`に修正（実使用バージョンとの不整合を解消）
- `spots/views.py`: homeビュー・searchビューにDjango Paginatorを導入（12件/ページ）
- `templates/spots/home.html`: Bootstrapベースのページナビゲーションを追加
- `templates/spots/search.html`: 検索パラメータ保持付きページナビゲーションを追加
- `spots/tests.py`: ページネーションのユニットテスト追加

## 対応Issue
Closes #12

## 動作確認手順
1. `flake8 accounts/ spots/ config/ --max-line-length=120 --exclude=migrations` でlintパスを確認
2. `python manage.py test accounts spots --verbosity=2` で全41テスト通過を確認
3. 15件以上のスポットを登録し、ページ遷移が動作することを確認