### PR TITLE
画像アップロードのバリデーション機能を追加

### DIFF
--- a/spots/forms.py
+++ b/spots/forms.py
@@ -1,5 +1,22 @@
 from django import forms
+from django.core.exceptions import ValidationError
 from .models import Spot, SpotImage, Comment
+
+ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
+MAX_IMAGE_SIZE = 5 * 1024 * 1024  # 5MB
+
+
+def validate_image_file(f):
+    """画像ファイルの拡張子・MIMEタイプ・サイズをバリデーションする"""
+    if f.content_type not in ALLOWED_IMAGE_TYPES:
+        raise ValidationError(
+            f"対応していない画像形式です（{f.content_type}）。"
+            "JPEG, PNG, WebP, GIF のみ対応しています。"
+        )
+    if f.size > MAX_IMAGE_SIZE:
+        raise ValidationError(
+            f"画像サイズが上限（5MB）を超えています（{f.size / (1024 * 1024):.1f}MB）。"
+        )
 
 
 class SpotForm(forms.ModelForm):

--- a/spots/tests.py
+++ b/spots/tests.py
@@ -1,7 +1,10 @@
+from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.contrib.auth.models import User
 from django.urls import reverse
 
+from .forms import validate_image_file, MAX_IMAGE_SIZE
 from .models import Category, Spot, Like, Bookmark, Comment
 
 
@@ -326,3 +329,94 @@ class SpotCommentPostTest(TestCase):
         url = reverse("spots:spot_detail", kwargs={"pk": self.spot.pk})
         response = self.client.post(url, {"text": "いいね！"})
         self.assertRedirects(response, url)
+
+
+class ImageValidationTest(TestCase):
+    """画像アップロードバリデーションのテスト"""
+
+    def test_valid_jpeg_passes(self):
+        """JPEG画像はバリデーションを通過する"""
+        f = SimpleUploadedFile("photo.jpg", b"\xff\xd8\xff" + b"\x00" * 100, content_type="image/jpeg")
+        validate_image_file(f)  # 例外が発生しないことを確認
+
+    def test_valid_png_passes(self):
+        """PNG画像はバリデーションを通過する"""
+        f = SimpleUploadedFile("photo.png", b"\x89PNG" + b"\x00" * 100, content_type="image/png")
+        validate_image_file(f)
+
+    def test_valid_webp_passes(self):
+        """WebP画像はバリデーションを通過する"""
+        f = SimpleUploadedFile("photo.webp", b"RIFF" + b"\x00" * 100, content_type="image/webp")
+        validate_image_file(f)
+
+    def test_valid_gif_passes(self):
+        """GIF画像はバリデーションを通過する"""
+        f = SimpleUploadedFile("photo.gif", b"GIF89a" + b"\x00" * 100, content_type="image/gif")
+        validate_image_file(f)
+
+    def test_pdf_rejected(self):
+        """PDFファイルは拒否される"""
+        f = SimpleUploadedFile("document.pdf", b"%PDF-1.4", content_type="application/pdf")
+        with self.assertRaises(ValidationError) as ctx:
+            validate_image_file(f)
+        self.assertIn("対応していない画像形式", ctx.exception.message)
+
+    def test_text_file_rejected(self):
+        """テキストファイルは拒否される"""
+        f = SimpleUploadedFile("file.txt", b"hello world", content_type="text/plain")
+        with self.assertRaises(ValidationError):
+            validate_image_file(f)
+
+    def test_oversized_image_rejected(self):
+        """5MBを超える画像は拒否される"""
+        large_data = b"\x00" * (MAX_IMAGE_SIZE + 1)
+        f = SimpleUploadedFile("huge.jpg", large_data, content_type="image/jpeg")
+        with self.assertRaises(ValidationError) as ctx:
+            validate_image_file(f)
+        self.assertIn("上限", ctx.exception.message)
+
+    def test_image_at_max_size_passes(self):
+        """5MBちょうどの画像はバリデーションを通過する"""
+        data = b"\x00" * MAX_IMAGE_SIZE
+        f = SimpleUploadedFile("ok.jpg", data, content_type="image/jpeg")
+        validate_image_file(f)
+
+
+class SpotCreateImageValidationTest(TestCase):
+    """スポット作成時の画像バリデーション統合テスト"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="taro", password="pass1234")
+        self.category = Category.objects.create(name="カフェ", slug="cafe")
+        self.client.login(username="taro", password="pass1234")
+
+    def _make_image(self, name="photo.jpg", content_type="image/jpeg", size=100):
+        return SimpleUploadedFile(name, b"\xff\xd8\xff" + b"\x00" * size, content_type=content_type)
+
+    def test_create_with_invalid_file_type_shows_error(self):
+        """非画像ファイルでスポット作成するとエラーが表示される"""
+        url = reverse("spots:spot_create")
+        pdf = SimpleUploadedFile("doc.pdf", b"%PDF-1.4" + b"\x00" * 100, content_type="application/pdf")
+        response = self.client.post(url, {
+            "title": "テスト",
+            "description": "説明",
+            "area": "渋谷",
+            "category": self.category.pk,
+            "images": [pdf],
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Spot.objects.exists())
+
+    def test_create_with_valid_image_succeeds(self):
+        """有効な画像でスポット作成が成功する"""
+        url = reverse("spots:spot_create")
+        img = self._make_image()
+        response = self.client.post(url, {
+            "title": "テスト",
+            "description": "説明",
+            "area": "渋谷",
+            "category": self.category.pk,
+            "images": [img],
+        })
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(Spot.objects.exists())

--- a/spots/views.py
+++ b/spots/views.py
@@ -1,9 +1,10 @@
+from django.core.exceptions import ValidationError
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 from django.db.models import Q
 from .models import Spot, SpotImage, Like, Bookmark, Category
-from .forms import SpotForm, CommentForm
+from .forms import SpotForm, CommentForm, validate_image_file
 
 
 def home(request):
@@ -21,12 +22,19 @@ def spot_create(request):
             if not files:
                 form.add_error(None, "画像を1枚以上アップロードしてください。")
             else:
-                spot = form.save(commit=False)
-                spot.author = request.user
-                spot.save()
-                for i, f in enumerate(files):
-                    SpotImage.objects.create(spot=spot, image=f, order=i)
-                return redirect("spots:spot_detail", pk=spot.pk)
+                for f in files:
+                    try:
+                        validate_image_file(f)
+                    except ValidationError as e:
+                        form.add_error(None, e.message)
+                        break
+                if not form.errors:
+                    spot = form.save(commit=False)
+                    spot.author = request.user
+                    spot.save()
+                    for i, f in enumerate(files):
+                        SpotImage.objects.create(spot=spot, image=f, order=i)
+                    return redirect("spots:spot_detail", pk=spot.pk)
     else:
         form = SpotForm()
     return render(request, "spots/spot_create.html", {"form": form})
@@ -72,12 +80,20 @@ def spot_edit(request, pk):
         form = SpotForm(request.POST, instance=spot)
         files = request.FILES.getlist("images")
         if form.is_valid():
-            form.save()
             if files:
-                spot.images.all().delete()
-                for i, f in enumerate(files):
-                    SpotImage.objects.create(spot=spot, image=f, order=i)
-            return redirect("spots:spot_detail", pk=spot.pk)
+                for f in files:
+                    try:
+                        validate_image_file(f)
+                    except ValidationError as e:
+                        form.add_error(None, e.message)
+                        break
+            if not form.errors:
+                form.save()
+                if files:
+                    spot.images.all().delete()
+                    for i, f in enumerate(files):
+                        SpotImage.objects.create(spot=spot, image=f, order=i)
+                return redirect("spots:spot_detail", pk=spot.pk)
     else:
         form = SpotForm(instance=spot)
     return render(request, "spots/spot_edit.html", {"form": form, "spot": spot})


### PR DESCRIPTION
## 変更概要

- 画像アップロード時のMIMEタイプチェック（JPEG/PNG/WebP/GIF のみ許可）を追加
- 画像ファイルサイズ上限チェック（最大5MB）を追加
- `spot_create` と `spot_edit` の両ビューにバリデーションを適用
- ユニットテスト10件を追加（バリデーション関数8件 + 統合テスト2件）
- flake8 lint + Django test 全50件パス確認済み

Closes #14

## 動作確認手順

1. `DJANGO_SECRET_KEY=test DEBUG=True python manage.py test accounts spots -v 2` で全テストパス
2. `flake8 accounts/ spots/ config/ --max-line-length=120 --exclude=migrations` でlintパス
3. スポット作成画面でPDFファイルをアップロードするとエラーメッセージが表示されることを確認