### PR TITLE
feat: 本番セキュリティ設定の追加とパスワードリセット機能の実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DJANGO_SECRET_KEY=your-secret-key-here
+DEBUG=True
+ALLOWED_HOSTS=localhost,127.0.0.1

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -109,3 +109,56 @@ class BookmarkListViewTest(TestCase):
         url = reverse("accounts:bookmark_list")
         response = self.client.get(url)
         self.assertRedirects(response, reverse("accounts:login") + "?next=" + url)
+
+
+class PasswordResetViewTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="taro", password="pass1234", email="taro@example.com"
+        )
+
+    def test_password_reset_page_returns_200(self):
+        """パスワードリセットページが表示される"""
+        url = reverse("accounts:password_reset")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_password_reset_done_page_returns_200(self):
+        """パスワードリセットメール送信完了ページが表示される"""
+        url = reverse("accounts:password_reset_done")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_password_reset_complete_page_returns_200(self):
+        """パスワードリセット完了ページが表示される"""
+        url = reverse("accounts:password_reset_complete")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_password_reset_post_redirects(self):
+        """パスワードリセットフォーム送信後にリダイレクトされる"""
+        url = reverse("accounts:password_reset")
+        response = self.client.post(url, {"email": "taro@example.com"})
+        self.assertRedirects(response, "/accounts/password_reset/done/")
+
+    def test_password_reset_confirm_invalid_link(self):
+        """無効なトークンでパスワードリセット確認ページにアクセス"""
+        url = reverse(
+            "accounts:password_reset_confirm",
+            kwargs={"uidb64": "invalid", "token": "invalid-token"},
+        )
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.status_code, 200)
+
+
+class SecuritySettingsTest(TestCase):
+    def test_production_security_settings(self):
+        """本番環境のセキュリティ設定が正しく定義されている"""
+        import inspect
+        import config.settings as raw_settings
+        source = inspect.getsource(raw_settings)
+        self.assertIn("SECURE_SSL_REDIRECT", source)
+        self.assertIn("SECURE_HSTS_SECONDS", source)
+        self.assertIn("SESSION_COOKIE_SECURE", source)
+        self.assertIn("CSRF_COOKIE_SECURE", source)
+        self.assertIn("SECURE_PROXY_SSL_HEADER", source)

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -12,6 +12,21 @@ urlpatterns = [
         name="login",
     ),
     path("logout/", auth_views.LogoutView.as_view(), name="logout"),
+    path("password_reset/", auth_views.PasswordResetView.as_view(
+        template_name="accounts/password_reset.html",
+        email_template_name="accounts/password_reset_email.html",
+        success_url="/accounts/password_reset/done/",
+    ), name="password_reset"),
+    path("password_reset/done/", auth_views.PasswordResetDoneView.as_view(
+        template_name="accounts/password_reset_done.html",
+    ), name="password_reset_done"),
+    path("reset/<uidb64>/<token>/", auth_views.PasswordResetConfirmView.as_view(
+        template_name="accounts/password_reset_confirm.html",
+        success_url="/accounts/reset/done/",
+    ), name="password_reset_confirm"),
+    path("reset/done/", auth_views.PasswordResetCompleteView.as_view(
+        template_name="accounts/password_reset_complete.html",
+    ), name="password_reset_complete"),
     path("profile/edit/", views.profile_edit, name="profile_edit"),
     path("bookmarks/", views.bookmark_list, name="bookmark_list"),
     path("<str:username>/", views.user_profile, name="user_profile"),

--- a/config/settings.py
+++ b/config/settings.py
@@ -84,3 +84,13 @@ LOGIN_REDIRECT_URL = "spots:home"
 LOGOUT_REDIRECT_URL = "spots:home"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# 本番環境セキュリティ設定（DEBUG=False時のみ有効）
+if not DEBUG:
+    SECURE_SSL_REDIRECT = True
+    SECURE_HSTS_SECONDS = 31536000
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -23,7 +23,10 @@
         {% endif %}
         <button type="submit" class="btn btn-warning w-100 fw-bold py-2">ログイン</button>
       </form>
-      <p class="text-center mt-3 mb-0 small">
+      <p class="text-center mt-3 mb-1 small">
+        <a href="{% url 'accounts:password_reset' %}">パスワードをお忘れですか？</a>
+      </p>
+      <p class="text-center mb-0 small">
         アカウントをお持ちでないですか？ <a href="{% url 'accounts:signup' %}">新規登録</a>
       </p>
     </div>

--- a/templates/accounts/password_reset.html
+++ b/templates/accounts/password_reset.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block title %}パスワードリセット - VibeMap{% endblock %}
+
+{% block content %}
+<div class="auth-container">
+  <div class="card border-0 shadow-sm" style="border-radius:16px;">
+    <div class="card-body p-4">
+      <h3 class="text-center fw-bold mb-1"><i class="bi bi-geo-alt-fill text-warning"></i></h3>
+      <h4 class="text-center fw-bold mb-4">パスワードリセット</h4>
+      <p class="text-muted small text-center mb-3">
+        登録済みのメールアドレスを入力してください。パスワードリセット用のリンクをお送りします。
+      </p>
+      <form method="post">
+        {% csrf_token %}
+        <div class="mb-3">
+          <label class="form-label fw-bold small">メールアドレス</label>
+          <input type="email" name="email" class="form-control" required autofocus>
+        </div>
+        {% if form.errors %}
+        <div class="alert alert-danger small py-2">入力内容を確認してください。</div>
+        {% endif %}
+        <button type="submit" class="btn btn-warning w-100 fw-bold py-2">リセットリンクを送信</button>
+      </form>
+      <p class="text-center mt-3 mb-0 small">
+        <a href="{% url 'accounts:login' %}">ログインに戻る</a>
+      </p>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/accounts/password_reset_complete.html
+++ b/templates/accounts/password_reset_complete.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %}パスワード変更完了 - VibeMap{% endblock %}
+
+{% block content %}
+<div class="auth-container">
+  <div class="card border-0 shadow-sm" style="border-radius:16px;">
+    <div class="card-body p-4">
+      <h3 class="text-center fw-bold mb-1"><i class="bi bi-check-circle-fill text-warning"></i></h3>
+      <h4 class="text-center fw-bold mb-4">パスワード変更完了</h4>
+      <p class="text-muted small text-center mb-3">
+        パスワードが正常に変更されました。新しいパスワードでログインしてください。
+      </p>
+      <a href="{% url 'accounts:login' %}" class="btn btn-warning w-100 fw-bold py-2">ログイン</a>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/accounts/password_reset_confirm.html
+++ b/templates/accounts/password_reset_confirm.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block title %}新しいパスワードの設定 - VibeMap{% endblock %}
+
+{% block content %}
+<div class="auth-container">
+  <div class="card border-0 shadow-sm" style="border-radius:16px;">
+    <div class="card-body p-4">
+      <h3 class="text-center fw-bold mb-1"><i class="bi bi-key-fill text-warning"></i></h3>
+      <h4 class="text-center fw-bold mb-4">新しいパスワードの設定</h4>
+      {% if validlink %}
+      <form method="post">
+        {% csrf_token %}
+        <div class="mb-3">
+          <label class="form-label fw-bold small">新しいパスワード</label>
+          <input type="password" name="new_password1" class="form-control" required autofocus>
+        </div>
+        <div class="mb-3">
+          <label class="form-label fw-bold small">新しいパスワード（確認）</label>
+          <input type="password" name="new_password2" class="form-control" required>
+        </div>
+        {% if form.errors %}
+        <div class="alert alert-danger small py-2">
+          {% for field in form %}
+            {% for error in field.errors %}
+              <p class="mb-0">{{ error }}</p>
+            {% endfor %}
+          {% endfor %}
+        </div>
+        {% endif %}
+        <button type="submit" class="btn btn-warning w-100 fw-bold py-2">パスワードを変更</button>
+      </form>
+      {% else %}
+      <div class="alert alert-danger small py-2">
+        このパスワードリセットリンクは無効です。すでに使用されたか、期限が切れている可能性があります。
+      </div>
+      <a href="{% url 'accounts:password_reset' %}" class="btn btn-warning w-100 fw-bold py-2">もう一度リセットする</a>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/accounts/password_reset_done.html
+++ b/templates/accounts/password_reset_done.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block title %}メール送信完了 - VibeMap{% endblock %}
+
+{% block content %}
+<div class="auth-container">
+  <div class="card border-0 shadow-sm" style="border-radius:16px;">
+    <div class="card-body p-4">
+      <h3 class="text-center fw-bold mb-1"><i class="bi bi-envelope-check text-warning"></i></h3>
+      <h4 class="text-center fw-bold mb-4">メールを送信しました</h4>
+      <p class="text-muted small text-center mb-3">
+        パスワードリセット用のリンクをメールでお送りしました。メールをご確認ください。
+      </p>
+      <p class="text-muted small text-center mb-3">
+        メールが届かない場合は、入力したメールアドレスが正しいか確認してください。
+      </p>
+      <a href="{% url 'accounts:login' %}" class="btn btn-warning w-100 fw-bold py-2">ログインに戻る</a>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/accounts/password_reset_email.html
+++ b/templates/accounts/password_reset_email.html
@@ -1,0 +1,9 @@
+{{ user.username }} 様
+
+以下のリンクをクリックして、パスワードをリセットしてください：
+
+{{ protocol }}://{{ domain }}{% url 'accounts:password_reset_confirm' uidb64=uid token=token %}
+
+このリンクに心当たりがない場合は、このメールを無視してください。
+
+VibeMap


### PR DESCRIPTION
## 概要

本番環境向けのセキュリティ設定の追加と、Django組み込みのパスワードリセット機能の実装を行いました。

## 変更内容

- **本番環境セキュリティ設定**: `DEBUG=False` 時のみ有効になるSSL/HSTS/セキュアCookie設定を `config/settings.py` に追加
- **パスワードリセット機能**: Django組み込みの4画面（リセット申請・メール送信完了・新パスワード設定・完了）を追加
- **ログイン画面改善**: パスワードリセットリンクを追加
- **`.env.example`**: 環境変数テンプレートファイルを追加
- **テスト追加**: セキュリティ設定の存在確認テスト、パスワードリセット各URLのアクセステスト

## テスト計画

- [x] flake8 リントチェック通過（critical: 0、既存のseed.py E402のみ）
- [x] 全57テスト通過
- [ ] パスワードリセットフローの手動確認
- [ ] 本番環境（DEBUG=False）でのセキュリティヘッダー確認

Closes #16