### PR TITLE
feat: プロフィールページのスポット一覧にページネーションを追加

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -76,6 +76,28 @@ class UserProfileViewTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
+    def test_user_profile_pagination(self):
+        """プロフィールページのスポット一覧が12件ずつページネーションされる"""
+        from spots.models import Category, Spot
+
+        cat = Category.objects.create(name="カフェ", slug="cafe")
+        for i in range(15):
+            Spot.objects.create(
+                author=self.user,
+                title=f"スポット{i}",
+                description="説明",
+                area="渋谷",
+                category=cat,
+            )
+        url = reverse("accounts:user_profile", kwargs={"username": "taro"})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["spots"]), 12)
+
+        response2 = self.client.get(url + "?page=2")
+        self.assertEqual(response2.status_code, 200)
+        self.assertEqual(len(response2.context["spots"]), 3)
+
 
 class ProfileEditViewTest(TestCase):
     def setUp(self):

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -2,7 +2,10 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
+from django.core.paginator import Paginator
 from .forms import SignUpForm, ProfileForm
+
+PROFILE_SPOTS_PER_PAGE = 12
 
 
 def signup(request):
@@ -32,7 +35,10 @@ def profile_edit(request):
 
 def user_profile(request, username):
     user = get_object_or_404(User, username=username)
-    spots = user.spots.all()
+    spot_list = user.spots.select_related("category").prefetch_related("images")
+    paginator = Paginator(spot_list, PROFILE_SPOTS_PER_PAGE)
+    page_number = request.GET.get("page")
+    spots = paginator.get_page(page_number)
     return render(request, "accounts/user_profile.html", {"profile_user": user, "spots": spots})
 
 


### PR DESCRIPTION
## 変更概要

- `user_profile` ビューに `Paginator` を導入し、スポット一覧を12件ずつページネーション表示
- `select_related("category")` と `prefetch_related("images")` を追加しN+1クエリを解消
- `PROFILE_SPOTS_PER_PAGE` 定数で1ページあたりの表示件数を管理

Closes #21

## 動作確認手順

1. `python manage.py test accounts --verbosity=2` でテストがパスすることを確認
2. 15件以上のスポットを持つユーザーのプロフィールページで2ページ目が表示されることを確認