### PR TITLE
セキュリティ強化: いいね・ブックマークのHTTPメソッド制限追加

### DIFF
--- a/spots/test_filters_and_access.py
+++ b/spots/test_filters_and_access.py
@@ -140,3 +140,17 @@ class AccessControlTest(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertIn("/accounts/login", response["Location"])
         self.assertTrue(Spot.objects.filter(pk=self.spot.pk).exists())
+
+    def test_like_via_get_returns_405(self):
+        """GETリクエストによるいいね操作は405を返す"""
+        self.client.login(username="taro", password="pass1234")
+        url = reverse("spots:spot_like", kwargs={"pk": self.spot.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 405)
+
+    def test_bookmark_via_get_returns_405(self):
+        """GETリクエストによるブックマーク操作は405を返す"""
+        self.client.login(username="taro", password="pass1234")
+        url = reverse("spots:spot_bookmark", kwargs={"pk": self.spot.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 405)

--- a/spots/views.py
+++ b/spots/views.py
@@ -3,6 +3,7 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
 from django.http import JsonResponse
+from django.views.decorators.http import require_POST
 from django.db.models import Q
 from .models import Spot, SpotImage, Like, Bookmark, Category
 from .forms import SpotForm, CommentForm, validate_image_file
@@ -115,6 +116,7 @@ def spot_delete(request, pk):
 
 
 @login_required
+@require_POST
 def spot_like(request, pk):
     spot = get_object_or_404(Spot, pk=pk)
     like, created = Like.objects.get_or_create(user=request.user, spot=spot)
@@ -126,6 +128,7 @@ def spot_like(request, pk):
 
 
 @login_required
+@require_POST
 def spot_bookmark(request, pk):
     spot = get_object_or_404(Spot, pk=pk)
     bookmark, created = Bookmark.objects.get_or_create(user=request.user, spot=spot)


### PR DESCRIPTION
## 変更概要
- `spots/views.py`: `spot_like` と `spot_bookmark` ビューに `@require_POST` デコレータを追加
- GETリクエストによるいいね/ブックマークの切り替えを防止（CSRF攻撃の緩和）
- `spots/test_filters_and_access.py`: GETリクエストが405を返すことを検証するテスト2件を追加

Closes #23

## 動作確認手順
1. `python manage.py test accounts spots --verbosity=2` で全79テストがパスすること
2. `flake8 accounts/ spots/ config/ --max-line-length=120 --exclude=migrations` でlintエラーがないこと
3. ブラウザで `/spots/1/like/` にGETアクセスすると405が返ること