### PR TITLE
test: accounts・spotsのテストカバレッジ向上

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -99,6 +99,38 @@ class UserProfileViewTest(TestCase):
         self.assertEqual(len(response2.context["spots"]), 3)
 
 
+class SignUpDuplicateTest(TestCase):
+    """重複ユーザー名のサインアップテスト"""
+
+    def test_signup_duplicate_username_shows_error(self):
+        """既存ユーザー名でのサインアップはエラーを表示しユーザーが作成されない"""
+        User.objects.create_user(username="existing", password="pass1234")
+        response = self.client.post(
+            reverse("accounts:signup"),
+            {
+                "username": "existing",
+                "email": "new@example.com",
+                "password1": "Str0ngPass!",
+                "password2": "Str0ngPass!",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(User.objects.filter(username="existing").count(), 1)
+
+    def test_signup_auto_login(self):
+        """サインアップ成功後に自動ログインされホームにリダイレクトされる"""
+        response = self.client.post(
+            reverse("accounts:signup"),
+            {
+                "username": "newuser",
+                "email": "new@example.com",
+                "password1": "Str0ngPass!",
+                "password2": "Str0ngPass!",
+            },
+        )
+        self.assertRedirects(response, reverse("spots:home"))
+
+
 class ProfileEditViewTest(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="taro", password="pass1234")
@@ -114,6 +146,28 @@ class ProfileEditViewTest(TestCase):
         url = reverse("accounts:profile_edit")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+
+    def test_profile_edit_post_updates_display_name(self):
+        """プロフィール編集POSTで表示名が更新される"""
+        url = reverse("accounts:profile_edit")
+        response = self.client.post(url, {"display_name": "太郎", "bio": "自己紹介です"})
+        self.assertRedirects(
+            response,
+            reverse("accounts:user_profile", kwargs={"username": "taro"}),
+        )
+        self.user.profile.refresh_from_db()
+        self.assertEqual(self.user.profile.display_name, "太郎")
+        self.assertEqual(self.user.profile.bio, "自己紹介です")
+
+    def test_profile_edit_post_clears_display_name(self):
+        """表示名を空にするとユーザー名にフォールバックする"""
+        self.user.profile.display_name = "太郎"
+        self.user.profile.save()
+        url = reverse("accounts:profile_edit")
+        self.client.post(url, {"display_name": "", "bio": ""})
+        self.user.profile.refresh_from_db()
+        self.assertEqual(self.user.profile.display_name, "")
+        self.assertEqual(self.user.profile.get_display_name(), "taro")
 
 
 class BookmarkListViewTest(TestCase):

--- a/spots/tests.py
+++ b/spots/tests.py
@@ -530,3 +530,48 @@ class SpotCreateImageValidationTest(TestCase):
         })
         self.assertEqual(response.status_code, 302)
         self.assertTrue(Spot.objects.exists())
+
+    def test_create_without_images_shows_error(self):
+        """画像なしでスポット作成するとエラーが表示される"""
+        url = reverse("spots:spot_create")
+        response = self.client.post(url, {
+            "title": "テスト",
+            "description": "説明",
+            "area": "渋谷",
+            "category": self.category.pk,
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Spot.objects.exists())
+
+
+class SpotEditImageTest(TestCase):
+    """スポット編集時の画像処理テスト"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="taro", password="pass1234")
+        self.category = Category.objects.create(name="カフェ", slug="cafe")
+        self.spot = Spot.objects.create(
+            author=self.user, title="元のタイトル", description="元の説明",
+            area="渋谷", category=self.category,
+        )
+        img = SimpleUploadedFile("photo.jpg", b"\xff\xd8\xff" + b"\x00" * 100, content_type="image/jpeg")
+        from .models import SpotImage
+        SpotImage.objects.create(spot=self.spot, image=img, order=0)
+        self.client.login(username="taro", password="pass1234")
+
+    def test_edit_without_new_images_keeps_existing(self):
+        """画像をアップロードせずにスポットを編集すると既存画像が保持される"""
+        url = reverse("spots:spot_edit", kwargs={"pk": self.spot.pk})
+        response = self.client.post(url, {
+            "title": "新しいタイトル",
+            "description": "新しい説明",
+            "area": "新宿",
+            "category": self.category.pk,
+        })
+        self.assertRedirects(
+            response,
+            reverse("spots:spot_detail", kwargs={"pk": self.spot.pk}),
+        )
+        self.spot.refresh_from_db()
+        self.assertEqual(self.spot.title, "新しいタイトル")
+        self.assertEqual(self.spot.images.count(), 1)


### PR DESCRIPTION
## 変更概要

- `accounts/tests.py` にテスト4件追加
- `spots/tests.py` にテスト2件追加
- 全85テストパス確認済み

## 追加テスト

### accounts/tests.py
- `SignUpDuplicateTest.test_signup_duplicate_username_shows_error`: 既存ユーザー名での重複サインアップ
- `SignUpDuplicateTest.test_signup_auto_login`: サインアップ成功後の自動ログインとリダイレクト
- `ProfileEditViewTest.test_profile_edit_post_updates_display_name`: プロフィール編集POSTで表示名・自己紹介が更新される
- `ProfileEditViewTest.test_profile_edit_post_clears_display_name`: 表示名を空にするとユーザー名にフォールバック

### spots/tests.py
- `SpotCreateImageValidationTest.test_create_without_images_shows_error`: 画像なしでのスポット作成がエラーになる
- `SpotEditImageTest.test_edit_without_new_images_keeps_existing`: 画像なしの編集で既存画像が保持される

## 動作確認

```bash
python manage.py test accounts spots --verbosity=2
# 85 passed（既存79件 + 新規6件）
```

Closes #25