### PR TITLE
feat: ブックマーク一覧にページネーションを追加

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -186,6 +186,27 @@ class BookmarkListViewTest(TestCase):
         response = self.client.get(url)
         self.assertRedirects(response, reverse("accounts:login") + "?next=" + url)
 
+    def test_bookmark_list_pagination(self):
+        """ブックマーク一覧が12件ずつページネーションされる"""
+        from spots.models import Category, Spot, Bookmark
+
+        cat = Category.objects.create(name="カフェ", slug="cafe")
+        for i in range(15):
+            spot = Spot.objects.create(
+                author=self.user, title=f"スポット{i}",
+                description="説明", area="渋谷", category=cat,
+            )
+            Bookmark.objects.create(user=self.user, spot=spot)
+
+        url = reverse("accounts:bookmark_list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["bookmarks"]), 12)
+
+        response2 = self.client.get(url + "?page=2")
+        self.assertEqual(response2.status_code, 200)
+        self.assertEqual(len(response2.context["bookmarks"]), 3)
+
 
 class PasswordResetViewTest(TestCase):
     def setUp(self):

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -6,6 +6,7 @@ from django.core.paginator import Paginator
 from .forms import SignUpForm, ProfileForm
 
 PROFILE_SPOTS_PER_PAGE = 12
+BOOKMARKS_PER_PAGE = 12
 
 
 def signup(request):
@@ -44,5 +45,10 @@ def user_profile(request, username):
 
 @login_required
 def bookmark_list(request):
-    bookmarks = request.user.bookmarks.select_related("spot__category", "spot__author").all()
+    bookmark_qs = request.user.bookmarks.select_related(
+        "spot__category", "spot__author"
+    ).order_by("-created_at")
+    paginator = Paginator(bookmark_qs, BOOKMARKS_PER_PAGE)
+    page_number = request.GET.get("page")
+    bookmarks = paginator.get_page(page_number)
     return render(request, "accounts/bookmark_list.html", {"bookmarks": bookmarks})

--- a/templates/accounts/bookmark_list.html
+++ b/templates/accounts/bookmark_list.html
@@ -28,6 +28,25 @@
   </div>
   {% endfor %}
 </div>
+
+{% if bookmarks.has_other_pages %}
+<nav class="mt-4">
+  <ul class="pagination justify-content-center">
+    {% if bookmarks.has_previous %}
+    <li class="page-item"><a class="page-link" href="?page={{ bookmarks.previous_page_number }}">前へ</a></li>
+    {% endif %}
+    {% for num in bookmarks.paginator.page_range %}
+    <li class="page-item {% if bookmarks.number == num %}active{% endif %}">
+      <a class="page-link" href="?page={{ num }}">{{ num }}</a>
+    </li>
+    {% endfor %}
+    {% if bookmarks.has_next %}
+    <li class="page-item"><a class="page-link" href="?page={{ bookmarks.next_page_number }}">次へ</a></li>
+    {% endif %}
+  </ul>
+</nav>
+{% endif %}
+
 {% else %}
 <div class="text-center py-5">
   <i class="bi bi-bookmark" style="font-size:3rem;color:#ccc;"></i>


### PR DESCRIPTION
## 変更概要
- `accounts/views.py`: `bookmark_list`ビューに`Paginator`を適用（12件/ページ、新しい順）
- `templates/accounts/bookmark_list.html`: ページネーションナビゲーションUIを追加
- `accounts/tests.py`: ページネーションテストを追加（15件のブックマーク作成→1ページ目12件・2ページ目3件の検証）

Closes #27

## 動作確認
- `flake8 accounts/ spots/ config/ --max-line-length=120 --exclude=migrations` パス
- `python manage.py test accounts spots --verbosity=2` 全86テストパス